### PR TITLE
Fix cache key comparison

### DIFF
--- a/ProjectCeilidh.PortAudio/Native/PaDeviceIndex.cs
+++ b/ProjectCeilidh.PortAudio/Native/PaDeviceIndex.cs
@@ -2,7 +2,7 @@
 
 namespace ProjectCeilidh.PortAudio.Native
 {
-    internal readonly struct PaDeviceIndex : IComparable<PaDeviceIndex>
+    internal readonly struct PaDeviceIndex : IComparable<PaDeviceIndex>, IEquatable<PaDeviceIndex>
     {
         private readonly int _value;
 

--- a/ProjectCeilidh.PortAudio/Native/PaHostApiIndex.cs
+++ b/ProjectCeilidh.PortAudio/Native/PaHostApiIndex.cs
@@ -5,7 +5,7 @@ namespace ProjectCeilidh.PortAudio.Native
     /// <summary>
     /// Used to enumerate host APIs at runtime. Values of this type range from 0 to (<see cref="PortAudio.Pa_GetHostApiCount"/>-1).
     /// </summary>
-    internal readonly struct PaHostApiIndex : IComparable<PaHostApiIndex>
+    internal readonly struct PaHostApiIndex : IComparable<PaHostApiIndex>, IEquatable<PaHostApiIndex>
     {
         private readonly int _value;
 

--- a/ProjectCeilidh.PortAudio/ProjectCeilidh.PortAudio.csproj
+++ b/ProjectCeilidh.PortAudio/ProjectCeilidh.PortAudio.csproj
@@ -5,10 +5,10 @@
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Olivia Trewin</Authors>
     <Company>Project Ceilidh</Company>
-    <Description>C# bindings for PortAudio, targeting .NET Standard 2.0</Description>
+    <Description>C# bindings for PortAudio, targeting .NET Standard 1.1</Description>
     <Copyright>Olivia Trewin 2018</Copyright>
     <RepositoryUrl>https://github.com/Ceilidh-Team/PortAudio</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
For some reason, the default implementation of `Equals`/`GetHashCode` wasn't being invoked on `PaDeviceIndex` or `PaHostApiIndex`. Implementing `IEquatable` fixed that.